### PR TITLE
Fix Styles Props

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
 *.test.*
+packagehash.txt

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+packagehash.txt

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Marcador de Tranca
 
-## Iniciar o Projeto
+## Fist Step
 
 Clone this respository.
 
-In the project directory, you can run:
-
-### `npm install` or `yarn install`
+In the project directory, you can run: `npm install` or `yarn install`
 
 ## Available Scripts
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Marcador de Tranca
 
+## Iniciar o Projeto
+
+Clone this respository.
+
+In the project directory, you can run:
+
+### `npm install` or `yarn install`
+
 ## Available Scripts
 
 In the project directory, you can run:
@@ -12,11 +20,6 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.<br />
 You will also see any lint errors in the console.
 
-### `npm test`
-
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
 ### `npm run build`
 
 Builds the app for production to the `build` folder.<br />
@@ -27,18 +30,32 @@ Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-### `npm run eject`
+# CSS Style Pattern
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+## Rules
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+- All components already have `font-family: 'Dosis', sans-serif;`;
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+  **Note: In case of using another font, just add `font-family: ...` to the component CSS props.**;
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+- All screens must to be add a `margin: 2rem` to the top-head div container;
 
-## Learn More
+- All HTML component that will get any CSS style have to get a self `className` which will be use in `*.css` file.
 
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
+  - Avoid using the HTML names to style the components. Use the `className`, `id`, `name` or any other ref. For exemple:
 
-To learn React, check out the [React documentation](https://reactjs.org/).
+    ```css
+    /* WRONG */
+    div {
+      display: flex;
+      justify-content: center;
+      /* ... */
+    }
+
+    /* RIGHT */
+    .container {
+      display: flex;
+      justify-content: center;
+      /* ... */
+    }
+    ```

--- a/packagehash.txt
+++ b/packagehash.txt
@@ -1,1 +1,0 @@
-1b3ad37deafb3958d62846dfed5cd3c2

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="pt">
+<html lang="pt-br">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -2,11 +2,11 @@
   box-sizing: border-box;
   padding: 0px;
   margin: 0px;
+  font-family: 'Dosis', sans-serif;
 }
 
 body {
   align-items: center;
   justify-content: center;
-  max-height: 1440px;
   background-color: #000;
 }

--- a/src/components/button/button-page.styled.css
+++ b/src/components/button/button-page.styled.css
@@ -9,7 +9,6 @@
   height: 3.5rem;
   background-color: #fff;
   border: #000 solid 2px;
-  font-family: 'Dosis', sans-serif;
   font-weight: bold;
   font-size: large;
   margin: 0.5rem;
@@ -42,7 +41,6 @@
 
 .button-name {
   color: #000;
-  font-family: 'Dosis', sans-serif;
   text-align: end;
   font-style: normal;
   font-weight: 400;

--- a/src/components/button/common-button.styled.css
+++ b/src/components/button/common-button.styled.css
@@ -4,7 +4,6 @@
   text-transform: uppercase;
   text-align: center;
   cursor: pointer;
-  font-family: 'Dosis', sans-serif;
   border-radius: 1.5rem;
   width: 8rem;
   height: 2.5rem;

--- a/src/components/button/random-button.styled.css
+++ b/src/components/button/random-button.styled.css
@@ -6,7 +6,6 @@
   border-radius: 2rem;
   width: 9rem;
   height: 3.5rem;
-  font-family: 'Dosis', sans-serif;
   font-weight: bold;
   margin: 0.5rem;
   cursor: pointer;

--- a/src/pages/about/about.page.styles.css
+++ b/src/pages/about/about.page.styles.css
@@ -1,20 +1,20 @@
-div {
+.containier-about {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 0px 70px 0px;
 }
 
-h1 {
+.title-about {
   color: #c1272d;
-  font-family: "Dosis", sans-serif;
+  font-family: 'Dosis', sans-serif;
   padding: 5px;
   align-items: center;
 }
 
-p {
+.paragraph-about {
   color: white;
-  font-family: "Roboto", sans-serif;
+  font-family: 'Roboto', sans-serif;
   text-align: justify;
   font-style: italic;
   font-weight: normal;
@@ -22,7 +22,7 @@ p {
 
 .Criadores {
   color: white;
-  font-family: "Roboto", sans-serif;
+  font-family: 'Roboto', sans-serif;
   font-weight: medium;
   font-style: normal;
   font-size: 10px;

--- a/src/pages/about/about.page.styles.css
+++ b/src/pages/about/about.page.styles.css
@@ -2,17 +2,17 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 0px 70px 0px;
+  height: 100%;
 }
 
 .title-about {
+  margin: 2rem;
   color: #c1272d;
-  font-family: 'Dosis', sans-serif;
-  padding: 5px;
-  align-items: center;
+  text-align: center;
 }
 
 .paragraph-about {
+  margin: 2rem;
   color: white;
   font-family: 'Roboto', sans-serif;
   text-align: justify;
@@ -26,5 +26,23 @@
   font-weight: medium;
   font-style: normal;
   font-size: 10px;
-  text-align: center;
+  margin: 2rem;
+}
+/**
+* .Criadores está com um bug de centralização
+* Com o aumento do margin, o componente movimenta-se
+* para a direita, saindo da centralização.
+* Fazendo bottom 2rem e margin 0 resolve o problema.
+*/
+@media screen and (min-width: 700px) {
+  .Criadores {
+    position: absolute;
+    bottom: 2rem;
+    margin: 0;
+  }
+
+  .containier-about {
+    position: absolute;
+    height: 100%;
+  }
 }

--- a/src/pages/about/about.page.tsx
+++ b/src/pages/about/about.page.tsx
@@ -23,13 +23,8 @@ export function About() {
         entusiasta da programação, e pra mim isso foi um grande momento de aprendizado e prática sobre o assunto.
         Apresento-lhes então, o Marcador de Pontos. Espero que possam aproveitá-lo tanto quanto eu estou aproveitando :)
       </p>
-      <p className="Criadores">
-        Criadores:
-        <br />
-        Rodrigo Gobatto e Lucas Gobatto
-      </p>
-      <br />
       <ButtonPage title="Inicio" icon="home" />
+      <p className="Criadores">Rodrigo Gobatto e Lucas Gobatto</p>
     </div>
   );
 }

--- a/src/pages/about/about.page.tsx
+++ b/src/pages/about/about.page.tsx
@@ -4,9 +4,9 @@ import './about.page.styles.css';
 
 export function About() {
   return (
-    <div>
-      <h1>De onde veio a ideia de fazer o app?</h1>
-      <p>
+    <div className="containier-about">
+      <h1 className="title-about">De onde veio a ideia de fazer o app?</h1>
+      <p className="paragraph-about">
         Na nossa família, todo mundo gosta de jogar tranca. E quando nos reunimos, vamos longe. 1h, 2h às vezes até 3h
         da manhã jogando. Pensa num monte de velhinho que costuma acordar 5h30 indo dormir às 3h. Enfim, sempre que
         jogamos acontece a mesma coisa: acaba a partida e precisamos anotar os pontos. Junto com o baralho já deixamos o

--- a/src/pages/home/home.page.styles.css
+++ b/src/pages/home/home.page.styles.css
@@ -1,9 +1,10 @@
 .home {
   display: flex;
+  margin: 2rem;
   flex-direction: column;
   align-items: center;
 }
 
 .logo {
-  margin-top: 17%;
+  margin: 2rem;
 }

--- a/src/pages/newgame/new-game.page.styles.css
+++ b/src/pages/newgame/new-game.page.styles.css
@@ -1,10 +1,10 @@
 .container {
-  display: block;
+  display: flex;
   position: absolute;
   width: 100%;
   height: 100%;
   flex-direction: column;
-  padding-top: 15vh;
+  padding: 2rem;
   align-items: center;
   background-color: #fff;
 }
@@ -16,14 +16,20 @@
   }
 }
 
-.equip-contianer {
+.equip-container {
   display: grid;
   align-items: center;
   text-align: center;
   justify-content: center;
-  margin: 5vh;
+  margin: 2rem 0px;
 }
 
 .button-container {
-  margin: 1rem;
+  margin: 1.5rem;
+}
+
+.equip-names {
+  color: #c1272d;
+  text-align: center;
+  text-transform: uppercase;
 }

--- a/src/pages/rules/rules.page.styles.css
+++ b/src/pages/rules/rules.page.styles.css
@@ -10,12 +10,14 @@
   text-align: center;
   text-transform: uppercase;
   width: 100%;
+  margin: 1rem 0;
 }
 
 .topic-rules {
   color: #c1272d;
   text-align: center;
   width: 100%;
+  margin: 0.5rem 0;
 }
 
 .paragraph-rules {
@@ -26,10 +28,11 @@
   font-style: normal;
   font-weight: 400;
   width: 100%;
+  margin: 0.5rem 0;
 }
 
-.rules-image {
+.image-rules {
   max-width: 289px;
   max-height: 75px;
-  padding: 10px;
+  margin: 1rem 0;
 }

--- a/src/pages/rules/rules.page.styles.css
+++ b/src/pages/rules/rules.page.styles.css
@@ -1,26 +1,26 @@
-div {
+.container-rules {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 0px 50px 0px;
 }
 
-h1 {
+.title-rules {
   color: #c1272d;
-  font-family: "Dosis", sans-serif;
+  font-family: 'Dosis', sans-serif;
   align-items: center;
   text-transform: uppercase;
 }
 
-h2 {
+.topic-rules {
   color: #c1272d;
-  font-family: "Dosis", sans-serif;
+  font-family: 'Dosis', sans-serif;
   align-items: center;
 }
 
-p {
+.paragraph-rules {
   color: white;
-  font-family: "Roboto", sans-serif;
+  font-family: 'Roboto', sans-serif;
   text-align: justify;
   font-style: normal;
   font-weight: 400;

--- a/src/pages/rules/rules.page.styles.css
+++ b/src/pages/rules/rules.page.styles.css
@@ -2,32 +2,34 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 0px 50px 0px;
+  margin: 2rem;
 }
 
 .title-rules {
   color: #c1272d;
-  font-family: 'Dosis', sans-serif;
-  align-items: center;
+  text-align: center;
   text-transform: uppercase;
+  width: 100%;
 }
 
 .topic-rules {
   color: #c1272d;
-  font-family: 'Dosis', sans-serif;
-  align-items: center;
+  text-align: center;
+  width: 100%;
 }
 
 .paragraph-rules {
+  text-align: center;
   color: white;
   font-family: 'Roboto', sans-serif;
   text-align: justify;
   font-style: normal;
   font-weight: 400;
+  width: 100%;
 }
 
-.Regras {
-  width: 289px;
-  height: 75px;
+.rules-image {
+  max-width: 289px;
+  max-height: 75px;
   padding: 10px;
 }

--- a/src/pages/rules/rules.page.tsx
+++ b/src/pages/rules/rules.page.tsx
@@ -121,8 +121,8 @@ export function Rules() {
         <b>Canastra -</b> Jogo de sete cartas ou mais do mesmo valor de qualquer naipe, ou jogo de sete cartas em
         sequência, do mesmo naipe. Existem dois tipos de canastra, a suja que tem coringa e a limpa que não tem:
       </p>
-      <img className="rules-image" src={CanastraSuja} alt="Canastra Limpa" />
-      <img className="rules-image" src={CanastraLimpa} alt="Canastra Suja" />
+      <img className="image-rules" src={CanastraSuja} alt="Canastra Limpa" />
+      <img className="image-rules" src={CanastraLimpa} alt="Canastra Suja" />
       <br />
 
       <h2 className="topic-rules">Contagem dos pontos</h2>

--- a/src/pages/rules/rules.page.tsx
+++ b/src/pages/rules/rules.page.tsx
@@ -121,8 +121,8 @@ export function Rules() {
         <b>Canastra -</b> Jogo de sete cartas ou mais do mesmo valor de qualquer naipe, ou jogo de sete cartas em
         sequência, do mesmo naipe. Existem dois tipos de canastra, a suja que tem coringa e a limpa que não tem:
       </p>
-      <img className="Regras" src={CanastraSuja} alt="Canastra Limpa" />
-      <img className="Regras" src={CanastraLimpa} alt="Canastra Suja" />
+      <img className="rules-image" src={CanastraSuja} alt="Canastra Limpa" />
+      <img className="rules-image" src={CanastraLimpa} alt="Canastra Suja" />
       <br />
 
       <h2 className="topic-rules">Contagem dos pontos</h2>

--- a/src/pages/rules/rules.page.tsx
+++ b/src/pages/rules/rules.page.tsx
@@ -6,10 +6,10 @@ import CanastraLimpa from '@assets/images/canastra-limpa.jpg';
 
 export function Rules() {
   return (
-    <div>
-      <h1>Regras</h1>
-      <h2>Formatação</h2>
-      <p>
+    <div className="container-rules">
+      <h1 className="title-rules">Regras</h1>
+      <h2 className="topic-rules">Formatação</h2>
+      <p className="paragraph-rules">
         Pode ser jogado com dois ou quatro jogadores.
         <br />
         <br />
@@ -32,8 +32,8 @@ export function Rules() {
       </p>
       <br />
 
-      <h2>Como funciona</h2>
-      <p>
+      <h2 className="topic-rules">Como funciona</h2>
+      <p className="paragraph-rules">
         O primeiro jogador compra uma carta do monte ou do lixo, verifica quais são as combinações que pode fazer com
         essa carta e joga fora uma que não lhe interesse. Essa carta vai para a lixeira. Após o descarte, é a vez do
         jogador à esquerda daquele que começou a rodada, e assim por diante. Do segundo jogador em diante, existe a
@@ -56,8 +56,8 @@ export function Rules() {
         morto, serão descontados 100 pontos correspondentes ao morto, além das cartas que o jogador tiver em mãos.
       </p>
 
-      <h2>Convenções</h2>
-      <p>
+      <h2 className="topic-rules">Convenções</h2>
+      <p className="paragraph-rules">
         Pode trinca (também chamada de "lavadeira")
         <br />
         Não tem Joker (também chamado de "curingão")
@@ -67,8 +67,8 @@ export function Rules() {
         Pode bater com canastra suja
       </p>
 
-      <h2>Convenções</h2>
-      <p>
+      <h2 className="topic-rules">Convenções</h2>
+      <p className="paragraph-rules">
         <b>Baixar um jogo –</b> Um jogo é formado por 3 ou mais cartas do mesmo naipe, ordenadas em sequência numérica
         ou três ou mais cartas do mesmo valor, independente do naipe (trinca). No decorrer da partida podem-se
         acrescentar mais cartas ao jogo.
@@ -125,8 +125,8 @@ export function Rules() {
       <img className="Regras" src={CanastraLimpa} alt="Canastra Suja" />
       <br />
 
-      <h2>Contagem dos pontos</h2>
-      <p>
+      <h2 className="topic-rules">Contagem dos pontos</h2>
+      <p className="paragraph-rules">
         Ao término da partida, somam-se os pontos na mesa, ou seja, os valores das cartas baixadas e o valor extra das
         canastras. Descontam-se os valores das cartas que sobraram nas mãos de cada jogador.
         <br />
@@ -137,7 +137,7 @@ export function Rules() {
         comprado.
       </p>
       <br />
-      <h2>Outras Regras</h2>
+      <h2 className="topic-rules">Outras Regras</h2>
       <ButtonURL site="Jogatina" url="https://www.jogatina.com/regras-como-jogar-tranca.html" />
       <ButtonURL site="Jogos do Rei" url="http://www.jogosdorei.com.br/regras-tranca.php" />
       <ButtonURL site="Net Cartas" url="https://netcartas.com.br/tranca/regras.jsp" />


### PR DESCRIPTION
O React tem alguns problemas com o CSS. Se não usarmos nomes específicos para referenciar os componentes no arquivo `*.css` e usarmos apenas `div`, ou `h1` etc, todos so componentes `div`, `h1` etc, receberão o estilo. Portanto, para resolver esse problema, eu referenciei todos os componentes e tentei aplicar um padrão para a estilização destes e dos próximos, evitando conflitos e deixando os componentes mais previsíveis, lembrando que padronização de estilo influencia demais na UX. Atualizei o README.md com umas regrinhas para facilitar um pouco.

Edit: Se tiver algum erro de gramática da um toque que eu corrijo hehehe.